### PR TITLE
Add an option to handle HTTP scheme

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -38,6 +38,35 @@
             </intent-filter>
         </activity>
         <activity
+            android:name=".HttpSchemeHandlerActivity"
+            android:enabled="false"
+            android:autoRemoveFromRecents="true"
+            android:excludeFromRecents="true"
+            android:noHistory="true">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW"/>
+
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+
+                <data android:scheme="http"/>
+                <data android:scheme="https"/>
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW"/>
+
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+
+                <data android:scheme="http"/>
+                <data android:scheme="https"/>
+                <data android:mimeType="text/html"/>
+                <data android:mimeType="text/plain"/>
+                <data android:mimeType="application/xhtml+xml"/>
+                <data android:mimeType="application/vnd.wap.xhtml+xml"/>
+            </intent-filter>
+        </activity>
+        <activity
             android:name=".AccountsManagementActivity"
             android:label="@string/title_activity_accounts_management"
             android:parentActivityName=".MainActivity" >

--- a/app/src/main/java/com/dimtion/shaarlier/HttpSchemeHandlerActivity.java
+++ b/app/src/main/java/com/dimtion/shaarlier/HttpSchemeHandlerActivity.java
@@ -1,0 +1,31 @@
+package com.dimtion.shaarlier;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.net.Uri;
+import android.os.Bundle;
+import android.widget.Toast;
+
+public class HttpSchemeHandlerActivity extends Activity {
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        Uri data = getIntent().getData();
+        if(data != null) {
+            String url = data.toString();
+
+            Intent addActivityIntent = new Intent(this, AddActivity.class);
+            addActivityIntent.setAction(Intent.ACTION_SEND);
+            addActivityIntent.setType("text/plain");
+            addActivityIntent.putExtra(Intent.EXTRA_TEXT, url);
+            startActivity(addActivityIntent);
+        } else {
+            Toast.makeText(getApplicationContext(), R.string.add_not_handle, Toast.LENGTH_SHORT).show();
+        }
+
+        finish();
+    }
+
+}

--- a/app/src/main/java/com/dimtion/shaarlier/MainActivity.java
+++ b/app/src/main/java/com/dimtion/shaarlier/MainActivity.java
@@ -24,6 +24,8 @@ import android.widget.TextView;
 public class MainActivity extends AppCompatActivity {
     private boolean m_isNoAccount;
 
+    private boolean isHandlingHttpScheme;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -72,29 +74,19 @@ public class MainActivity extends AppCompatActivity {
         boolean isShareDialog = ((CheckBox) findViewById(R.id.show_share_dialog)).isChecked();
         boolean isAutoTitle = ((CheckBox) findViewById(R.id.auto_load_title)).isChecked();
         boolean isAutoDescription = ((CheckBox) findViewById(R.id.auto_load_description)).isChecked();
-        boolean isHandleHttpScheme = ((CheckBox) findViewById(R.id.handle_http_scheme)).isChecked();
-
-        SharedPreferences pref = getSharedPreferences(getString(R.string.params), MODE_PRIVATE);
-
-        boolean currentHandleHttpScheme = pref.getBoolean(getString(R.string.p_handle_http_scheme), false);
-
+        boolean isHandlingHttpSchemeNewValue = ((CheckBox) findViewById(R.id.handle_http_scheme)).isChecked();
         // Save data :
+        SharedPreferences pref = getSharedPreferences(getString(R.string.params), MODE_PRIVATE);
         SharedPreferences.Editor editor = pref.edit();
         editor.putBoolean(getString(R.string.p_default_private), isPrivate)
                 .putBoolean(getString(R.string.p_show_share_dialog), isShareDialog)
                 .putBoolean(getString(R.string.p_auto_title), isAutoTitle)
                 .putBoolean(getString(R.string.p_auto_description), isAutoDescription)
-                .putBoolean(getString(R.string.p_handle_http_scheme), isHandleHttpScheme)
                 .apply();
 
-        if(currentHandleHttpScheme != isHandleHttpScheme) {
-            ComponentName component = new ComponentName(this, HttpSchemeHandlerActivity.class);
-
-            int flag = (isHandleHttpScheme ? PackageManager.COMPONENT_ENABLED_STATE_ENABLED
-                    : PackageManager.COMPONENT_ENABLED_STATE_DISABLED);
-
-            getPackageManager().setComponentEnabledSetting(
-                    component, flag, PackageManager.DONT_KILL_APP);
+        if(isHandlingHttpSchemeNewValue != isHandlingHttpScheme) {
+            isHandlingHttpScheme = isHandlingHttpSchemeNewValue;
+            setHandleHttpScheme(isHandlingHttpSchemeNewValue);
         }
     }
 
@@ -119,7 +111,7 @@ public class MainActivity extends AppCompatActivity {
         boolean sherDial = pref.getBoolean(getString(R.string.p_show_share_dialog), true);
         boolean isAutoTitle = pref.getBoolean(getString(R.string.p_auto_title), true);
         boolean isAutoDescription = pref.getBoolean(getString(R.string.p_auto_description), false);
-        boolean isHandleHttpScheme = pref.getBoolean(getString(R.string.p_handle_http_scheme), false);
+        isHandlingHttpScheme = isHandlingHttpScheme();
 
         // Retrieve interface :
         CheckBox privateCheck = (CheckBox) findViewById(R.id.default_private);
@@ -132,7 +124,7 @@ public class MainActivity extends AppCompatActivity {
         privateCheck.setChecked(prv);
         autoTitleCheck.setChecked(isAutoTitle);
         autoDescriptionCheck.setChecked(isAutoDescription);
-        handleHttpSchemeCheck.setChecked(isHandleHttpScheme);
+        handleHttpSchemeCheck.setChecked(isHandlingHttpScheme);
         shareDialogCheck.setChecked(sherDial);
     }
 
@@ -211,6 +203,23 @@ public class MainActivity extends AppCompatActivity {
         }
 
         return super.onOptionsItemSelected(item);
+    }
+
+    private boolean isHandlingHttpScheme() {
+        return getPackageManager().getComponentEnabledSetting(getHttpSchemeHandlingComponent())
+                == PackageManager.COMPONENT_ENABLED_STATE_ENABLED;
+    }
+
+    private void setHandleHttpScheme(boolean handleHttpScheme) {
+        int flag = (handleHttpScheme ? PackageManager.COMPONENT_ENABLED_STATE_ENABLED
+                : PackageManager.COMPONENT_ENABLED_STATE_DISABLED);
+
+        getPackageManager().setComponentEnabledSetting(
+                getHttpSchemeHandlingComponent(), flag, PackageManager.DONT_KILL_APP);
+    }
+
+    private ComponentName getHttpSchemeHandlingComponent() {
+        return new ComponentName(this, HttpSchemeHandlerActivity.class);
     }
 
 }

--- a/app/src/main/java/com/dimtion/shaarlier/MainActivity.java
+++ b/app/src/main/java/com/dimtion/shaarlier/MainActivity.java
@@ -1,6 +1,7 @@
 package com.dimtion.shaarlier;
 
 import android.app.AlertDialog;
+import android.content.ComponentName;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
@@ -71,15 +72,30 @@ public class MainActivity extends AppCompatActivity {
         boolean isShareDialog = ((CheckBox) findViewById(R.id.show_share_dialog)).isChecked();
         boolean isAutoTitle = ((CheckBox) findViewById(R.id.auto_load_title)).isChecked();
         boolean isAutoDescription = ((CheckBox) findViewById(R.id.auto_load_description)).isChecked();
-        // Save data :
+        boolean isHandleHttpScheme = ((CheckBox) findViewById(R.id.handle_http_scheme)).isChecked();
+
         SharedPreferences pref = getSharedPreferences(getString(R.string.params), MODE_PRIVATE);
+
+        boolean currentHandleHttpScheme = pref.getBoolean(getString(R.string.p_handle_http_scheme), false);
+
+        // Save data :
         SharedPreferences.Editor editor = pref.edit();
         editor.putBoolean(getString(R.string.p_default_private), isPrivate)
                 .putBoolean(getString(R.string.p_show_share_dialog), isShareDialog)
                 .putBoolean(getString(R.string.p_auto_title), isAutoTitle)
                 .putBoolean(getString(R.string.p_auto_description), isAutoDescription)
+                .putBoolean(getString(R.string.p_handle_http_scheme), isHandleHttpScheme)
                 .apply();
 
+        if(currentHandleHttpScheme != isHandleHttpScheme) {
+            ComponentName component = new ComponentName(this, HttpSchemeHandlerActivity.class);
+
+            int flag = (isHandleHttpScheme ? PackageManager.COMPONENT_ENABLED_STATE_ENABLED
+                    : PackageManager.COMPONENT_ENABLED_STATE_DISABLED);
+
+            getPackageManager().setComponentEnabledSetting(
+                    component, flag, PackageManager.DONT_KILL_APP);
+        }
     }
 
     public void openAccountsManager(View view) {
@@ -103,17 +119,20 @@ public class MainActivity extends AppCompatActivity {
         boolean sherDial = pref.getBoolean(getString(R.string.p_show_share_dialog), true);
         boolean isAutoTitle = pref.getBoolean(getString(R.string.p_auto_title), true);
         boolean isAutoDescription = pref.getBoolean(getString(R.string.p_auto_description), false);
+        boolean isHandleHttpScheme = pref.getBoolean(getString(R.string.p_handle_http_scheme), false);
 
         // Retrieve interface :
         CheckBox privateCheck = (CheckBox) findViewById(R.id.default_private);
         CheckBox shareDialogCheck = (CheckBox) findViewById(R.id.show_share_dialog);
         CheckBox autoTitleCheck = (CheckBox) findViewById(R.id.auto_load_title);
         CheckBox autoDescriptionCheck = (CheckBox) findViewById(R.id.auto_load_description);
+        CheckBox handleHttpSchemeCheck = (CheckBox) findViewById(R.id.handle_http_scheme);
 
         // Display user previous settings :
         privateCheck.setChecked(prv);
         autoTitleCheck.setChecked(isAutoTitle);
         autoDescriptionCheck.setChecked(isAutoDescription);
+        handleHttpSchemeCheck.setChecked(isHandleHttpScheme);
         shareDialogCheck.setChecked(sherDial);
     }
 

--- a/app/src/main/java/com/dimtion/shaarlier/MainActivity.java
+++ b/app/src/main/java/com/dimtion/shaarlier/MainActivity.java
@@ -24,8 +24,6 @@ import android.widget.TextView;
 public class MainActivity extends AppCompatActivity {
     private boolean m_isNoAccount;
 
-    private boolean isHandlingHttpScheme;
-
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -74,7 +72,7 @@ public class MainActivity extends AppCompatActivity {
         boolean isShareDialog = ((CheckBox) findViewById(R.id.show_share_dialog)).isChecked();
         boolean isAutoTitle = ((CheckBox) findViewById(R.id.auto_load_title)).isChecked();
         boolean isAutoDescription = ((CheckBox) findViewById(R.id.auto_load_description)).isChecked();
-        boolean isHandlingHttpSchemeNewValue = ((CheckBox) findViewById(R.id.handle_http_scheme)).isChecked();
+        boolean isHandlingHttpScheme = ((CheckBox) findViewById(R.id.handle_http_scheme)).isChecked();
         // Save data :
         SharedPreferences pref = getSharedPreferences(getString(R.string.params), MODE_PRIVATE);
         SharedPreferences.Editor editor = pref.edit();
@@ -84,10 +82,7 @@ public class MainActivity extends AppCompatActivity {
                 .putBoolean(getString(R.string.p_auto_description), isAutoDescription)
                 .apply();
 
-        if(isHandlingHttpSchemeNewValue != isHandlingHttpScheme) {
-            isHandlingHttpScheme = isHandlingHttpSchemeNewValue;
-            setHandleHttpScheme(isHandlingHttpSchemeNewValue);
-        }
+        setHandleHttpScheme(isHandlingHttpScheme);
     }
 
     public void openAccountsManager(View view) {
@@ -111,7 +106,7 @@ public class MainActivity extends AppCompatActivity {
         boolean sherDial = pref.getBoolean(getString(R.string.p_show_share_dialog), true);
         boolean isAutoTitle = pref.getBoolean(getString(R.string.p_auto_title), true);
         boolean isAutoDescription = pref.getBoolean(getString(R.string.p_auto_description), false);
-        isHandlingHttpScheme = isHandlingHttpScheme();
+        boolean isHandlingHttpScheme = isHandlingHttpScheme();
 
         // Retrieve interface :
         CheckBox privateCheck = (CheckBox) findViewById(R.id.default_private);
@@ -211,6 +206,8 @@ public class MainActivity extends AppCompatActivity {
     }
 
     private void setHandleHttpScheme(boolean handleHttpScheme) {
+        if(handleHttpScheme == isHandlingHttpScheme()) return;
+
         int flag = (handleHttpScheme ? PackageManager.COMPONENT_ENABLED_STATE_ENABLED
                 : PackageManager.COMPONENT_ENABLED_STATE_DISABLED);
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -77,6 +77,14 @@
             android:checked="true"
             android:text="@string/auto_load_description" />
 
+        <CheckBox
+            android:id="@+id/handle_http_scheme"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="5dp"
+            android:checked="true"
+            android:text="@string/handle_http_scheme" />
+
         <TextView
             android:id="@+id/textView4"
             android:layout_width="wrap_content"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -82,7 +82,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="5dp"
-            android:checked="true"
+            android:checked="false"
             android:text="@string/handle_http_scheme" />
 
         <TextView

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -56,6 +56,7 @@ Cette application est fièrement développée par dimtion, vous pouvez me trouve
     <string name="send_report">Vous pensez que c\'est un bug ?</string>
     <string name="report_issue">Voulez-vous signaler ce bug ?</string>
     <string name="auto_load_description">Charger automatiquement la description</string>
+    <string name="handle_http_scheme">Afficher Shaarlier dans la liste des navigateurs web</string>
     <string name="basic_auth">Authentification HTTP</string>
     <string name="error_retrieving_description">Aucune description n\'a été trouvé</string>
     <string name="error_unknown">Une erreur inconnue s\'est produite</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -40,6 +40,7 @@
     <string name="p_user_url" translatable="false">com.dimtion.shaarlier.p_user_url</string>
     <string name="p_auto_title" translatable="false">com.dimtion.shaarlier.auto_title</string>
     <string name="p_auto_description" translatable="false">com.dimtion.shaarlier.auto_description</string>
+    <string name="p_handle_http_scheme" translatable="false">com.dimtion.shaarlier.p_handle_http_scheme</string>
     <string name="p_version" translatable="false">com.dimtion.shaarlier.p_version</string>
     <string name="p_default_account" translatable="false">com.dimtion.shaarlier.p_default_account</string>
     <string name="saved_tags" translatable="false">com.dimtion.shaarlier.saved_tags</string>
@@ -89,5 +90,6 @@
     <string name="report_issue">Would you like to report this issue ?</string>
     <string name="loading_description_hint">Loading description…</string>
     <string name="auto_load_description">Automatically load page description</string>
+    <string name="handle_http_scheme">Show Shaarlier in the list of web browsers</string>
     <string name="version">"Version %1$s"</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -40,7 +40,6 @@
     <string name="p_user_url" translatable="false">com.dimtion.shaarlier.p_user_url</string>
     <string name="p_auto_title" translatable="false">com.dimtion.shaarlier.auto_title</string>
     <string name="p_auto_description" translatable="false">com.dimtion.shaarlier.auto_description</string>
-    <string name="p_handle_http_scheme" translatable="false">com.dimtion.shaarlier.p_handle_http_scheme</string>
     <string name="p_version" translatable="false">com.dimtion.shaarlier.p_version</string>
     <string name="p_default_account" translatable="false">com.dimtion.shaarlier.p_default_account</string>
     <string name="saved_tags" translatable="false">com.dimtion.shaarlier.saved_tags</string>


### PR DESCRIPTION
Useful when you want to save a link from an app which opens links in web browsers by default.
The option is disabled by default.
