### PR TITLE
Set proper proxy theme

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,7 +18,8 @@
             android:excludeFromRecents="true"
             android:label="@string/title_activity_share"
             android:noHistory="true"
-            android:taskAffinity="com.dimtion.Shaarlier.share">
+            android:taskAffinity="com.dimtion.Shaarlier.share"
+            android:theme="@style/ProxyTheme">
             <intent-filter>
                 <action android:name="android.intent.action.SEND" />
                 <category android:name="android.intent.category.DEFAULT" />
@@ -40,7 +41,8 @@
             android:autoRemoveFromRecents="true"
             android:enabled="false"
             android:excludeFromRecents="true"
-            android:noHistory="true">
+            android:noHistory="true"
+            android:theme="@style/ProxyTheme">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 

--- a/app/src/main/java/com/dimtion/shaarlier/activities/ShareActivity.java
+++ b/app/src/main/java/com/dimtion/shaarlier/activities/ShareActivity.java
@@ -61,10 +61,14 @@ public class ShareActivity extends AppCompatActivity {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
+        userPrefs = UserPreferences.load(this);
+        if(userPrefs.isOpenDialog()) {
+            setTheme(R.style.AppTheme);
+        }
+
         super.onCreate(savedInstanceState);
 
         Intent intent = getIntent();
-        userPrefs = UserPreferences.load(this);
 
         loadAccounts();
         if (accounts.isEmpty()) {

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -5,4 +5,15 @@
         <!-- Customize your theme here. -->
     </style>
 
+    <style name="ProxyTheme" parent="Theme.AppCompat.NoActionBar">
+        <item name="windowNoTitle">true</item>
+        <item name="android:windowBackground">@android:color/transparent</item>
+        <item name="android:colorBackgroundCacheHint">@null</item>
+        <item name="android:windowIsTranslucent">true</item>
+        <item name="android:windowAnimationStyle">@android:style/Animation</item>
+        <item name="android:windowContentOverlay">@null</item>
+        <item name="android:windowIsFloating">true</item>
+        <item name="android:backgroundDimEnabled">false</item>
+    </style>
+
 </resources>


### PR DESCRIPTION
There's that annoying activity switching animation when sharing to Shaalier if it doesn't display dialog (so there's no activity to switch to). This proxy theme removes the animation.

This works fine (used in [wallabag android app](https://github.com/wallabag/android-app) for a couple of years already) if the window is guaranteed not to display any UI, but may have side effects if the activity optionally shows UI. I tested the dialog mode only on Android 9 - it works ok, but the activity switching animation was different (probably because of `windowIsTranslucent`).
Maybe having a separate activity that never shows anything would work better.

I figured you should know about it, even so this is not a proper solution.