### PR TITLE
Fix the title and description retrieve broken

### DIFF
--- a/app/src/main/java/com/dimtion/shaarlier/activities/ShareActivity.java
+++ b/app/src/main/java/com/dimtion/shaarlier/activities/ShareActivity.java
@@ -562,6 +562,10 @@ public class ShareActivity extends AppCompatActivity {
                         if (isNotNewLink) {
                             defaults = prefetchedLink;
 
+                            // prefetch success: stop other loaders
+                            setLoading(LOADER_TITLE, false);
+                            setLoading(LOADER_DESCRIPTION, false);
+
                             // Update the interface
                             if (defaults.getTitle().length() > 0) {
                                 updateTitle(defaults.getTitle(), false);
@@ -581,9 +585,6 @@ public class ShareActivity extends AppCompatActivity {
                         } else {
                             isEditedIcon.setVisible(false);
                         }
-                        // prefetch success: stop other loaders
-                        setLoading(LOADER_TITLE, false);
-                        setLoading(LOADER_DESCRIPTION, false);
                         updateLoadersVisibility();
                     }
                     break;


### PR DESCRIPTION
There since c8d2d6f157319e0504f0249faf5af2941c4497ae. Restore the seems unexpected changes.

I believe it also fixes issues #53 and #54.