### PR TITLE
Fix 1 syntax issue in EN translation string

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,13 +4,13 @@
     <string name="action_settings">Settings</string>
     <string name="add_error">An error occurred during sharing</string>
     <string name="add_not_handle">Unhandled content</string>
-    <string name="add_success">Your link have been shared</string>
+    <string name="add_success">Your link has been shared</string>
     <string name="default_private">New links are private by default</string>
     <string name="description_hint">Description</string>
     <string name="error_connecting">The given url does not seems to work</string>
     <string name="error_internet_connection">No internet connection</string>
     <string name="error_login">Wrong credentials</string>
-    <string name="error_parsing_token">The given url is not a compatible Shaarli</string>
+    <string name="error_parsing_token">The given url is not a compatible Shaarli instance</string>
     <string name="error_url">The url is wrong</string>
     <string name="error_retrieving_tags">Could not load tags</string>
     <string name="logo_description">Shaarli logo</string>
@@ -26,7 +26,7 @@
     <string name="user_name">Username</string>
     <string name="user_password">Password</string>
     <string name="basic_auth">HTTP Basic Authentication</string>
-    <string name="your_shaarli_url">Your Shaarli url :</string>
+    <string name="your_shaarli_url">Your Shaarli url:</string>
 
     <string name="params" translatable="false">com.dimtion.shaarliposter.parms</string>
     <string name="p_url_shaarli" translatable="false">com.dimtion.shaarliposter.p_url_shaarli</string>
@@ -82,13 +82,13 @@
     <string name="check_default_account">Default account</string>
     <string name="button_delete_account">Delete account</string>
     <string name="title_activity_add_account">New account</string>
-    <string name="text_confirm_deletion_account">Are you sure you want to delete this account ?</string>
+    <string name="text_confirm_deletion_account">Are you sure you want to delete this account?</string>
     <string name="dbKey" translatable="false">com.dimtion.shaarlier.database_key</string>
     <string name="check_disable_cert_validation">Disable certificate validation (unsecure)</string>
     <string name="error_unknown">An unknown error has occurred</string>
     <string name="add_account">Add account</string>
-    <string name="send_report">You think this is a bug ?</string>
-    <string name="report_issue">Would you like to report this issue ?</string>
+    <string name="send_report">You think this is a bug?</string>
+    <string name="report_issue">Would you like to report this issue?</string>
     <string name="loading_description_hint">Loading description…</string>
     <string name="auto_load_description">Automatically load page description</string>
     <string name="handle_http_scheme">Show Shaarlier in the list of web browsers</string>


### PR DESCRIPTION
Love this project, the app is very useful and unobtrusive. . :clinking_glasses: 

I noticed a slight syntax error in the confirmation message, when a link has been shared.

I took the opportunity to fix spacing before a couple punctuation marks. (I know that in French there is a space before question marks and semi-colons, for instance, but in English that is not the norm.)