### PR TITLE
Fixes #55 Change tag separator to match with Shaarli

### DIFF
--- a/app/src/main/java/com/dimtion/shaarlier/utils/Link.java
+++ b/app/src/main/java/com/dimtion/shaarlier/utils/Link.java
@@ -83,7 +83,7 @@ public class Link implements Serializable {
     }
 
     public List<String> getTagList() {
-        return Arrays.asList(tags.split(", "));
+        return Arrays.asList(tags.split(" "));
     }
 
     public void setTags(String tags) {


### PR DESCRIPTION
Changing ", " to " " will return a list of tags separated by " " instead of ", " when fetching tags to post link to Shaarli.

This makes it consistent with the UI instructing to use spaces as tag separator ([here](https://github.com/dimtion/Shaarlier/blob/0ead375c90edfba5470658125d726421ada64d21/app/src/main/res/values/strings.xml#L20)).

A future improvement could be to allow the user to define a specific tag separator for the current Shaarli instance they are posting to.